### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,10 @@ module.exports = function(content, file, conf){
         if (file.cache) {
             file.cache.addDeps(target.realpath);
         }
-
+        //解决include_path 内import导致subpath为空报错问题
+        if(!target.subpath){
+            target.subpath = path.relative(root, target.realpath);
+        }
         ~sources.indexOf(target.subpath) || sources.push(target.subpath);
 
         done({


### PR DESCRIPTION
解决include_path 内import导致subpath为空报错问题。
比如业务模块A，引入common模块的sass库：bsass/_base.sass。
_base.sass内容：
```sass
@import 'core/vars'
@import 'core/css3'
```

A的fis-conf：
```js
fis.config.set('settings.parser.sass', {
    // 加入文件查找目录
    include_paths: ['../common/static/', '../common/static/bsass/', '../common/static/bsass/core', '../common/static/bsass/ui']
});
```

会因为subpath为空，而报错